### PR TITLE
fix(index): update instructions for Fedora

### DIFF
--- a/index.md
+++ b/index.md
@@ -143,9 +143,13 @@ The preceding repository also contains the Bash, Fish, and Zsh completions.
 
 ### Fedora
 
-Fedora support is in the works.
+[![Fedora package](https://repology.org/badge/version-for-repo/fedora_39/rust:eza.svg)](https://repology.org/project/eza/versions)
 
-https://bugzilla.redhat.com/show_bug.cgi?id=2238264
+Eza is available as the [eza](https://packages.fedoraproject.org/pkgs/rust-eza/eza/) package in the official Fedora repository.
+
+```bash
+sudo dnf install eza
+```
 
 ### Void Linux
 


### PR DESCRIPTION
Added an up to date description on how to install eza on Fedora, in accordance with https://github.com/eza-community/eza/blob/main/INSTALL.md.

Thanks for developing this awesome tool 🚀